### PR TITLE
Handle exception if any attribute is None

### DIFF
--- a/src/seutil/maven.py
+++ b/src/seutil/maven.py
@@ -92,8 +92,10 @@ class MavenModule:
             return
 
         pom = xmltodict.parse(io.load(self.project.dir / self.rel_path / "pom.xml", fmt=io.fmts.txt))
-
-        plugins = pom.get("project", {}).get("build", {}).get("plugins", {}).get("plugin", [])
+        try:
+            plugins = pom.get("project", {}).get("build", {}).get("plugins", {}).get("plugin", [])
+        except AttributeError:
+            plugins = []
         if not isinstance(plugins, list):
             plugins = [plugins]
             pom.get("build", {}).get("plugins", {})["plugin"] = plugins


### PR DESCRIPTION
I saw edge case where the "build" attribute is None in the parsed pom dict, so I added try catch block.